### PR TITLE
Update to newer version of ortools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ nose>=1.3
 flake8>=3.5
 numpy==1.15.4
 terminaltables==3.1.0
-ortools==6.7.4973
+ortools==7.3.7083
 coverage==4.5.2


### PR DESCRIPTION
Noticed the repl.it was complaining about an unfound version of `ortools`

```
Repl.it: Installing fresh packages

Collecting draftfast (from -r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/b8/d4/747e67a51e43a415bf60e5484aab42b7dc485968ccbca3d219216f91840f/draftfast-2.5.1.tar.gz
Collecting pandas (from -r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/7e/ab/ea76361f9d3e732e114adcd801d2820d5319c23d0ac5482fa3b412db217e/pandas-0.25.1-cp37-cp37m-manylinux1_x86_64.whl (10.4MB)
Collecting numpy==1.15.4 (from draftfast->-r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/38/39/f73e104d44f19a6203e786d5204532e214443ea2954917b27f3229e7639b/numpy-1.15.4-cp37-cp37m-manylinux1_x86_64.whl (13.8MB)
Collecting terminaltables==3.1.0 (from draftfast->-r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/9b/c4/4a21174f32f8a7e1104798c445dacdc1d4df86f2f26722767034e4de4bff/terminaltables-3.1.0.tar.gz
Collecting ortools==6.7.4973 (from draftfast->-r requirements.txt (line 1))
  Could not find a version that satisfies the requirement ortools==6.7.4973 (from draftfast->-r requirements.txt (line 1)) (from versions: 6.8.5452, 6.9.5822, 6.9.5824, 6.10.6025,7.0b6150, 7.0.6546, 7.1.6720, 7.2.6977, 7.3.7083)
No matching distribution found for ortools==6.7.4973 (from draftfast->-r requirements.txt(line 1))
You are using pip version 19.0.3, however version 19.2.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.


Repl.it: package installation failed!
```