### PR TITLE
Numpy and OR-Tools bumped to match requirements, enabling package installation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ testpath = "<0.4"
 google-apputils = "==0.4.2"
 nose = ">=1.3"
 "flake8" = ">=3.5"
-numpy = "==1.10.4"
+numpy = "==1.21.1"
 terminaltables = "==3.1.0"
 "autopep8" = "*"
 

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 requires = [
-    'numpy==1.15.4',
+    'numpy==1.21.1',
     'terminaltables==3.1.0',
-    'ortools==7.6.7691',
+    'ortools==9.0.9048',
 ]
 
 setuptools.setup(


### PR DESCRIPTION
At present, attempting to install this package for use in a Poetry-managed project (`poetry add draftfast`) results in the following:

```
Using version ^3.5.7 for draftfast

Updating dependencies
Resolving dependencies...

Writing lock file

Package operations: 3 installs, 1 update, 0 removals

  • Installing numpy (1.15.4)
  • Installing ortools (7.6.7691)
  • Installing terminaltables (3.1.0)

  RuntimeError

  Unable to find installation candidates for ortools (7.6.7691)

  at ~\.poetry\lib\poetry\installation\chooser.py:72 in choose_for
       68│
       69│             links.append(link)
       70│
       71│         if not links:
    →  72│             raise RuntimeError(
       73│                 "Unable to find installation candidates for {}".format(package)
       74│             )
       75│
       76│         # Get the best link
```
before eventually failing.

This PR updates `setup.py` and the `Pipfile` to reflect the versions specified in `requirements.txt`.
