### PR TITLE
Add new constants directory to hold rule configurations

### DIFF
--- a/draftfast/__init__.py
+++ b/draftfast/__init__.py
@@ -6,6 +6,7 @@ from draftfast import (
     exposure,
     pickem,
     showdown,
+    constants
 )
 
 assert optimize
@@ -15,3 +16,4 @@ assert csv_parse
 assert exposure
 assert pickem
 assert showdown
+assert constants

--- a/draftfast/constants/__init__.py
+++ b/draftfast/constants/__init__.py
@@ -1,0 +1,2 @@
+from roster_size import ROSTER_SIZE_BY_SITE
+from positions import POSITIONS_BY_SITE_BY_LEAGUE

--- a/draftfast/constants/__init__.py
+++ b/draftfast/constants/__init__.py
@@ -1,2 +1,2 @@
-from roster_size import ROSTER_SIZE_BY_SITE
+from roster_size import ROSTER_SIZE_BY_SITE_BY_SPORT
 from positions import POSITIONS_BY_SITE_BY_LEAGUE

--- a/draftfast/constants/__init__.py
+++ b/draftfast/constants/__init__.py
@@ -1,2 +1,5 @@
 from roster_size import ROSTER_SIZE_BY_SITE_BY_SPORT
 from positions import POSITIONS_BY_SITE_BY_LEAGUE
+
+assert ROSTER_SIZE_BY_SITE_BY_SPORT
+assert POSITIONS_BY_SITE_BY_LEAGUE

--- a/draftfast/constants/positions.py
+++ b/draftfast/constants/positions.py
@@ -1,0 +1,127 @@
+from draftfast.rules import get_nfl_positions, get_nfl_showdown_positions
+
+
+POSITIONS_BY_SITE_BY_LEAGUE = {
+    'DRAFT_KINGS': {
+        'NBA': [
+            ['PG', 1, 3],
+            ['SG', 1, 3],
+            ['SF', 1, 3],
+            ['PF', 1, 3],
+            ['C', 1, 2]
+        ],
+        'NBA_SHOWDOWN': [
+            ['CPT', 1, 1],
+            ['FLEX', 5, 5],
+        ],
+        'WNBA': [
+            ['PG', 1, 3],
+            ['SG', 1, 3],
+            ['SF', 1, 4],
+            ['PF', 1, 4],
+        ],
+        'NFL': get_nfl_positions(),
+        'NFL_SHOWDOWN': get_nfl_showdown_positions(dk=True),
+        'MLB': [
+            ['SP', 0, 2],
+            ['RP', 0, 2],
+            ['C', 1, 1],
+            ['1B', 1, 1],
+            ['2B', 1, 1],
+            ['3B', 1, 1],
+            ['SS', 1, 1],
+            ['OF', 3, 3],
+        ],
+        'SOCCER': [
+            ['F', 2, 3],
+            ['M', 2, 3],
+            ['D', 2, 3],
+            ['GK', 1, 2],
+        ],
+        'EL': [
+            ['G', 2, 3],
+            ['F', 3, 4],
+        ],
+        'NHL': [
+            ['C', 2, 3],
+            ['W', 3, 4],
+            ['D', 2, 3],
+            ['G', 1, 1],
+        ],
+        'NHL_SHOWDOWN': [
+            ['FLEX', 6, 6],
+        ],
+        'MLB_SHOWDOWN': [
+            ['CPT', 1, 1],
+            ['FLEX', 5, 5],
+        ],
+        'XFL': [
+            ['QB', 1, 1],
+            ['RB', 1, 3],
+            ['WR', 2, 4],
+            ['DST', 1, 1]
+        ],
+        'TEN': [
+            ['P', 6, 6],
+        ],
+        'PGA': [
+            ['G', 6, 6],
+        ],
+        'PGA_CAPTAIN': [
+            ['CPT', 1, 1],
+            ['G', 5, 5],
+        ],
+        'CSGO_SHOWDOWN': [
+            ['CPT', 1, 1],
+            ['FLEX', 5, 5],
+        ],
+        'F1_SHOWDOWN': [
+            ['CPT', 1, 1],
+            ['D', 4, 4],
+            ['CNSTR', 1, 1],
+        ],
+        'NASCAR': [
+            ['D', 6, 6],
+        ]
+    },
+    'FAN_DUEL': {
+        'NBA': [
+            ['PG', 2, 2],
+            ['SG', 2, 2],
+            ['SF', 2, 2],
+            ['PF', 2, 2],
+            ['C', 1, 1],
+        ],
+        'MLB': [
+            ['P', 1, 1],
+            ['1B', 1, 2],  # TODO - allow C or 1B
+            ['2B', 1, 2],
+            ['3B', 1, 2],
+            ['SS', 1, 2],
+            ['OF', 3, 4],
+        ],
+        'MLB_MVP': [
+            ['MVP', 1, 1],
+            ['STAR', 1, 1],
+            ['UTIL', 3, 3],
+        ],
+        'NBA_MVP': [
+            ['MVP', 1, 1],
+            ['STAR', 1, 1],
+            ['PRO', 1, 1],
+            ['UTIL', 2, 2],
+        ],
+        'WNBA': [
+            ['G', 3, 3],
+            ['F', 4, 4],
+        ],
+        'NFL': get_nfl_positions(d_abbrev='D'),
+        'NFL_MVP': get_nfl_showdown_positions(fd=True),
+        'NASCAR': [
+            ['D', 5, 5],
+        ],
+        'PGA': [
+            ['G', 6, 6],
+        ],
+    }
+}

--- a/draftfast/constants/roster_size.py
+++ b/draftfast/constants/roster_size.py
@@ -1,0 +1,33 @@
+ROSTER_SIZE_BY_SITE_BY_SPORT = {
+    'DRAFT_KINGS': {
+        'NFL': 9,
+        'NFL_SHOWDOWN': 6,
+        'MLB_SHOWDOWN': 6,
+        'NBA': 8,
+        'NBA_SHOWDOWN': 6,
+        'WNBA': 6,
+        'MLB': 10,
+        'SOCCER': 8,
+        'EL': 6,
+        'NHL': 9,
+        'NHL_SHOWDOWN': 6,
+        'XFL': 7,
+        'TEN': 6,
+        'PGA': 6,
+        'PGA_CAPTAIN': 6,
+        'CSGO_SHOWDOWN': 6,
+        'NASCAR': 6,
+        'F1_SHOWDOWN': 6,
+    },
+    'FAN_DUEL': {
+        'NFL': 9,
+        'NFL_MVP': 5,
+        'MLB_MVP': 5,
+        'NBA_MVP': 5,
+        'NBA': 9,
+        'MLB': 9,
+        'WNBA': 7,
+        'NASCAR': 5,
+        'PGA': 6,
+    }
+}


### PR DESCRIPTION
I think we could organize the rules a little bit better by introducing a directory that holds all of the static/constant rule configurations.

This is request does not modify any existing imports or logic that affects the package. This just adds new files to be used in followup pull requests